### PR TITLE
Extend ReaderStateQueries with Enumerable mixin.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.5.6. Add Enumerable capability to ReaderStateQueries.
+
 v0.5.5. Fixed crash in MRI 1.9.3.
 
 v0.5.4. Fixed ReaderStateQuery to work when the status has bits not defined in the PCSC header.


### PR DESCRIPTION
I felt a little bit uncomfortable in ReaderStateQuerie(s) handling. With Enumerable accessing ReaderStateQueries becomes more intuitive, e.g.:

```ruby
queries = Smartcard::PCSC::ReaderStateQueries.new(readers.size)
queries.each_with_index do |q, i|
  q.reader_name = readers[i]
  q.current_state = :empty
end
# ...
queries.select { |q| q.event_state.include? :present }.each do |query|
  # do stuff on readers with present cards
end
```

I've also increased version number.

cheers
--alex