### PR TITLE
Added USB Port Detection for Readers

### DIFF
--- a/lib/smartcard/pcsc/ffi_structs.rb
+++ b/lib/smartcard/pcsc/ffi_structs.rb
@@ -33,7 +33,8 @@ module FFILib
            :current_state, Word,
            :event_state, Word,
            :atr_length, Word,
-           :atr, [:char, Consts::MAX_ATR_SIZE]
+           :atr, [:char, Consts::MAX_ATR_SIZE],
+           :usb_address, :pointer
   end
   
   # Low-level protocol information for APDU transmission and reception.

--- a/lib/smartcard/pcsc/reader_state_queries.rb
+++ b/lib/smartcard/pcsc/reader_state_queries.rb
@@ -5,6 +5,7 @@
 # License:: MIT
 
 require 'set'
+require 'json'
 
 # :nodoc: namespace
 module Smartcard::PCSC
@@ -167,6 +168,19 @@ class FFILib::ReaderStateQuery
   def reader_name=(new_name)
     self[:reader_name].free if self[:reader_name].kind_of? FFI::MemoryPointer
     self[:reader_name] = FFI::MemoryPointer.from_string new_name
+  end
+
+  def usb_address
+    if self[:usb_address].null?
+      nil
+    else
+      JSON.parse(self[:usb_address].read_string, symbolize_names: true) 
+    end
+  end
+
+  def usb_address=(new_usb_address)
+    self[:usb_address].free if self[:usb_address].kind_of? FFI::MemoryPointer
+    self[:usb_address] = FFI::MemoryPointer.from_string(new_usb_address.to_json)
   end
 
   # Packs an unpacked card state (symbol or set of symbols) into a number.

--- a/test/pcsc/context_test.rb
+++ b/test/pcsc/context_test.rb
@@ -42,6 +42,23 @@ class ContextTest < Test::Unit::TestCase
                       'each reader name should be a string'
     end    
   end
+
+  def test_usb_port_for_reader
+    readers = @context.readers
+    readers.each do |reader|
+      usb_port = @context.usb_port_for_reader(reader)
+      if usb_port
+        assert_operator usb_port, :kind_of?, Hash, 'usb_port should be a Hash'
+        assert_includes usb_port, :bus, 'usb_port should include :bus key'  
+        assert_includes usb_port, :device_address, 'usb_port should include :device_address key'
+        
+        assert_operator usb_port[:bus], :kind_of?, Integer, ':bus should be an Integer'
+        assert_operator usb_port[:device_address], :kind_of?, Integer, ':device_address should be an Integer'
+      else
+        assert_nil usb_port, 'usb_port should be nil for non-USB reader or no card present'
+      end
+    end
+  end
   
   def test_wait_for_status_change
     readers = @context.readers

--- a/test/pcsc/reader_state_queries_test.rb
+++ b/test/pcsc/reader_state_queries_test.rb
@@ -4,6 +4,7 @@
 
 require 'rubygems'
 require 'smartcard'
+require 'json'
 
 require 'test/unit'
 
@@ -20,6 +21,8 @@ class ReaderStatesTest < Test::Unit::TestCase
     @queries[0].atr = 'grreat success'
     @queries[0].reader_name = 'PC/SC Reader 0'
     @queries[1].reader_name = 'CCID Reader 1'
+    @queries[0].usb_address = { :bus => 1, :device_address => 2 }
+    @queries[1].usb_address = { :bus => 1, :device_address => 4 }
   end
   
   def teardown
@@ -64,6 +67,11 @@ class ReaderStatesTest < Test::Unit::TestCase
   def test_reader_names
     assert_equal 'PC/SC Reader 0', @queries[0].reader_name
     assert_equal 'CCID Reader 1', @queries[1].reader_name
+  end
+
+  def test_usb_address
+    assert_equal({ :bus => 1, :device_address => 2 }, @queries[0].usb_address)
+    assert_equal({ :bus => 1, :device_address => 4 }, @queries[1].usb_address)
   end
   
   def test_ack_changes


### PR DESCRIPTION
To identify similar PCSC readers, I added a usb_port detection.
I also added a usb_address method to reader_state_query to store the usb_address there.